### PR TITLE
Dockerize Multiple Producers

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,5 +1,5 @@
 ---
-version: '2'
+version: "2"
 services:
   zookeeper:
     networks:
@@ -16,8 +16,8 @@ services:
     image: confluentinc/cp-kafka:5.0.0
     container_name: kafka
     labels:
-      - 'custom.project=kafkajs-zstd'
-      - 'custom.service=kafka'
+      - "custom.project=kafkajs-zstd"
+      - "custom.service=kafka"
     depends_on:
       - zookeeper
     ports:
@@ -30,17 +30,17 @@ services:
       KAFKA_INTER_BROKER_LISTENER_NAME: PLAINTEXT
       KAFKA_OFFSETS_TOPIC_REPLICATION_FACTOR: 1
       KAFKA_LOG4J_ROOT_LOGLEVEL: INFO
-      KAFKA_LOG4J_LOGGERS: 'kafka.controller=INFO,kafka.producer.async.DefaultEventHandler=INFO,state.change.logger=INFO'
-      CONFLUENT_SUPPORT_METRICS_ENABLE: 'false'
-  
+      KAFKA_LOG4J_LOGGERS: "kafka.controller=INFO,kafka.producer.async.DefaultEventHandler=INFO,state.change.logger=INFO"
+      CONFLUENT_SUPPORT_METRICS_ENABLE: "false"
+
   kafka1:
     networks:
       - kafka-net
     image: confluentinc/cp-kafka:5.0.0
     container_name: kafka1
     labels:
-      - 'custom.project=kafkajs-zstd'
-      - 'custom.service=kafka1'
+      - "custom.project=kafkajs-zstd"
+      - "custom.service=kafka1"
     depends_on:
       - zookeeper
     ports:
@@ -53,8 +53,8 @@ services:
       KAFKA_INTER_BROKER_LISTENER_NAME: PLAINTEXT
       KAFKA_OFFSETS_TOPIC_REPLICATION_FACTOR: 1
       KAFKA_LOG4J_ROOT_LOGLEVEL: INFO
-      KAFKA_LOG4J_LOGGERS: 'kafka.controller=INFO,kafka.producer.async.DefaultEventHandler=INFO,state.change.logger=INFO'
-      CONFLUENT_SUPPORT_METRICS_ENABLE: 'false'
+      KAFKA_LOG4J_LOGGERS: "kafka.controller=INFO,kafka.producer.async.DefaultEventHandler=INFO,state.change.logger=INFO"
+      CONFLUENT_SUPPORT_METRICS_ENABLE: "false"
 
   kafka2:
     networks:
@@ -62,8 +62,8 @@ services:
     image: confluentinc/cp-kafka:5.0.0
     container_name: kafka2
     labels:
-      - 'custom.project=kafkajs-zstd'
-      - 'custom.service=kafka2'
+      - "custom.project=kafkajs-zstd"
+      - "custom.service=kafka2"
     depends_on:
       - zookeeper
     ports:
@@ -76,13 +76,13 @@ services:
       KAFKA_INTER_BROKER_LISTENER_NAME: PLAINTEXT
       KAFKA_OFFSETS_TOPIC_REPLICATION_FACTOR: 1
       KAFKA_LOG4J_ROOT_LOGLEVEL: INFO
-      KAFKA_LOG4J_LOGGERS: 'kafka.controller=INFO,kafka.producer.async.DefaultEventHandler=INFO,state.change.logger=INFO'
-      CONFLUENT_SUPPORT_METRICS_ENABLE: 'false'
-  
+      KAFKA_LOG4J_LOGGERS: "kafka.controller=INFO,kafka.producer.async.DefaultEventHandler=INFO,state.change.logger=INFO"
+      CONFLUENT_SUPPORT_METRICS_ENABLE: "false"
+
   web-hook-server:
     networks:
       - kafka-net
-    build: 
+    build:
       context: .
       dockerfile: ./docker/server/Dockerfile
       args:
@@ -100,6 +100,33 @@ services:
     restart: always
     environment:
       - BOOTSTRAP_BROKERS=kafka:29092 kafka1:29092 kafka2:29092
+
+  producer-hochiminh:
+    build:
+      context: .
+      dockerfile: ./docker/producer/Dockerfile
+      args:
+        tag: parakafka/producer
+        progress: plain
+    environment:
+      - PRODUCER_NAME=HO CHI MINH CITY
+    container_name: producer_hochiminh
+    restart: always
+    network_mode: host
+  
+  producer-vungtau:
+    build:
+      context: .
+      dockerfile: ./docker/producer/Dockerfile
+      args:
+        tag: parakafka/producer
+        progress: plain
+    environment:
+      - PRODUCER_NAME=VUNG TAU PARADISE
+    container_name: producer_vungtau
+    restart: always
+    network_mode: host
+
   kafka-ui:
     networks:
       - kafka-net
@@ -117,7 +144,7 @@ services:
       KAFKA_CLUSTERS_0_NAME: kafka
       KAFKA_CLUSTERS_0_BOOTSTRAPSERVERS: kafka:29092, kafka1:29092, kafka2:29092
       KAFKA_CLUSTERS_0_ZOOKEEPER: zookeeper:2181
-      KAFKA_CLUSTERS_0_READONLY: 'false'
+      KAFKA_CLUSTERS_0_READONLY: "false"
 
 networks:
   kafka-net:

--- a/docker/producer/Dockerfile
+++ b/docker/producer/Dockerfile
@@ -1,0 +1,23 @@
+#! This has been integrated in docker compose to run along side kafka
+
+# Base
+FROM node:14
+
+# work dir
+WORKDIR /app
+
+# packages and .ENV
+COPY package*.json .
+COPY .env .
+RUN npm install
+
+# tools
+COPY ./src/tools ./src/tools
+# all shared source files
+COPY ./src/*.* ./src
+
+# related source
+COPY ./src/producer ./src/producer
+
+# commands
+CMD ["node", "src/producer/index.js"]

--- a/resource/test_payload.json
+++ b/resource/test_payload.json
@@ -1,9 +1,12 @@
-{ 
+{
   "event": "package:publish",
   "sender": "Produdez",
   "type": "package",
-  "hookOwner": { "username": "produdez"},
+  "hookOwner": {
+    "username": "produdez"
+  },
   "topic": "test-topic",
+  "partition": 0,
   "data": 1,
   "timestamp": 1603444214995
 }

--- a/src/config.js
+++ b/src/config.js
@@ -1,57 +1,61 @@
 // ! IMPORTANT: this is for setup needed things for every server/client environment that use this project
-require('./env_setup')
+require("./env_setup");
 
 // ! THESE ARE ALL THE MODULES and TOOLS
 
 const server = { port: process.env.PORT || 3000 };
 
-let env_brokers = process.env.BOOTSTRAP_BROKERS.split(' ')
-const brokers = env_brokers.length == 0 ? ['localhost:9092', 'localhost:9093', 'localhost:9094'] : env_brokers
+let env_brokers = process.env.BOOTSTRAP_BROKERS.split(" ");
+const brokers =
+	env_brokers.length == 0
+		? ["localhost:9092", "localhost:9093", "localhost:9094"]
+		: env_brokers;
 const kafka = {
-  clientId: 'parakafka',
-  brokers: brokers,
-  ssl: process.env.KAFKA_SSL ? JSON.parse(process.env.KAFKA_SSL) : false,
-  sasl:
-    process.env.KAFKA_USERNAME && process.env.KAFKA_PASSWORD
-      ? {
-          username: process.env.KAFKA_USERNAME,
-          password: process.env.KAFKA_PASSWORD,
-          mechanism: 'plain'
-        }
-      : null,
+	clientId: "parakafka",
+	brokers: brokers,
+	ssl: process.env.KAFKA_SSL ? JSON.parse(process.env.KAFKA_SSL) : false,
+	sasl:
+		process.env.KAFKA_USERNAME && process.env.KAFKA_PASSWORD
+			? {
+					username: process.env.KAFKA_USERNAME,
+					password: process.env.KAFKA_PASSWORD,
+					mechanism: "plain",
+			  }
+			: null,
 };
 
 const consumer = {
-  groupId: process.env.KAFKA_GROUP_ID || 'parakafka',
+	groupId: process.env.KAFKA_GROUP_ID || "parakafka",
 };
-
 
 const app = {
-  secret: process.env.HOOK_SECRET,
-  topic: process.env.TOPIC || 'test-topic',
-  mount: '/hook',
+	secret: process.env.HOOK_SECRET,
+	topic: process.env.TOPIC || "test-topic",
+	mount: "/hook",
 };
 
-const hook_url = (process.env.server_url || 'http://localhost:3000') + app.mount
+const hook_url =
+	(process.env.server_url || "http://localhost:3000") + app.mount;
 
 const producer = {
-  secret: app.secret,
-  topic: app.topic,
-  url: hook_url
-}
-
-const processor = {
-  topic: app.topic,
+	producer_name: process.env.PRODUCER_NAME,
+	secret: app.secret,
+	topic: app.topic,
+	url: hook_url,
 };
 
-const logger = require('./tools/winston_logger')
+const processor = {
+	topic: app.topic,
+};
+
+const logger = require("./tools/winston_logger");
 
 module.exports = {
-  server,
-  kafka,
-  consumer,
-  app,
-  processor,
-  producer,
-  logger,
+	server,
+	kafka,
+	consumer,
+	app,
+	processor,
+	producer,
+	logger,
 };

--- a/src/consumer/index.js
+++ b/src/consumer/index.js
@@ -1,5 +1,4 @@
 const { Kafka } = require("kafkajs");
-const { IncomingWebhook } = require("@slack/webhook");
 const config = require("../config");
 const logger = config.logger;
 const createConsumer = require("./consumer");

--- a/src/producer/producer.js
+++ b/src/producer/producer.js
@@ -1,84 +1,107 @@
-const logger = require('../config').logger
+const logger = require("../config").logger;
 
 let count = 0;
 
 module.exports = async ({ config }) => {
-  
-  logger.warn('Creating Producer!')
+	logger.warn(`Creating Producer ${config.producer_name}`);
 
-  return setInterval(() => {
-    send_data(config)
-  }, 3000);
+	// send accumulated (+1) number w/ random interval [2000, 5000]
+	var counter = 0;
+	const next_run = () => {
+		counter = randomInterval(2000, 10000, true);
+		send_data(config);
+		setTimeout(next_run, counter);
+	};
+	return setTimeout(next_run, counter);
 };
 
+async function send_data(config) {
+	data = gen_data(config.producer_name);
 
-async function send_data(config){
-    data = gen_data()
-    
-    payload = Buffer.from(JSON.stringify({
-      'data' : data,
-      'topic' : config.topic,
-      'timestamp' : Date.now(),
+	payload = Buffer.from(
+		JSON.stringify({
+			data: data,
+			topic: config.topic,
+			timestamp: Date.now(),
+			partition: 0, // why I just can send to partition 0...
 
-      //the ones below are just needed for webhook sending
-      "event": "package:publish",
-      "type": "package",
-      "hookOwner": { "username": "produdez"}
-    }))
+			//the ones below are just needed for webhook sending
+			event: "package:publish",
+			type: "package",
+			hookOwner: { username: "produdez" },
+		})
+	);
 
-    try{
-      await send_data_to_web_hook(payload, config.url, config.secret);
-      console.log(`Published payload through webhook of topic: ${config.topic} with data: ${data}`)
-    } catch (error) {
-      logger.error('Error publishing payload to webhook', error)
-      process.exit(1);  
-    }
+	try {
+		await send_data_to_web_hook(payload, config.url, config.secret);
+		console.log(
+			`Produde ${config.producer_name} published webhook, topic: ${config.topic} with data: ${data}`
+		);
+	} catch (error) {
+		logger.error("Error publishing payload to webhook", error);
+		process.exit(1);
+	}
 }
 
-function gen_data(){
-  return ++count
+function gen_data(producer_name) {
+	return `${producer_name} counts ${++count}`;
 }
 
-const http = require('http')
-const crypto = require('crypto')
+function randomInterval(min, max, log = false) {
+	const outputInteger = Math.floor(Math.random() * (max - min + 1)) + min;
+	if (log) logger.info(`Random interval generated: ${outputInteger}`);
+	return outputInteger;
+}
 
-async function send_data_to_web_hook(payload, url, secret){
+const http = require("http");
+const crypto = require("crypto");
 
-  if (!secret || !payload) {
-    throw 'Cant send data without secret-key and payload'
-  }
+async function send_data_to_web_hook(payload, url, secret) {
+	if (!secret || !payload) {
+		throw "Cant send data without secret-key and payload";
+	}
 
-  const signature = crypto.createHmac('sha256', secret).update(payload).digest('hex')
+	const signature = crypto
+		.createHmac("sha256", secret)
+		.update(payload)
+		.digest("hex");
 
+	return new Promise((resolve, reject) => {
+		const req = http.request(
+			url,
+			{
+				headers: {
+					"Content-Type": "application/json",
+					"x-npm-signature": `sha256=${signature}`,
+				},
+				method: "POST",
+			},
+			(res) => {
+				if (res.statusCode >= 400) {
+					reject(
+						new Error(
+							`Server returned statusCode ${res.statusCode}: ${res.statusMessage}`
+						)
+					);
+				} else {
+					res.setEncoding("utf-8");
+					let body = "";
+					res.on("data", (chunk) => (body += chunk));
+					res.on("end", () => {
+						logger.info(`Response: ${body}`);
+						resolve();
+					});
+				}
+			}
+		);
 
-  return new Promise((resolve, reject) => {
-      const req = http.request(url, {
-          headers: {
-              'Content-Type': 'application/json',
-              'x-npm-signature': `sha256=${signature}`
-          },
-          method: 'POST'
-      }, res => {
-          if (res.statusCode >= 400) {
-              reject(new Error(`Server returned statusCode ${res.statusCode}: ${res.statusMessage}`))
-          } else {
-              res.setEncoding('utf-8')
-              let body = ''
-              res.on('data', chunk => body += chunk)
-              res.on('end', () => {
-                  logger.info(`Response: ${body}`)
-                  resolve()
-              })
-          }
-      })
-      
-      req.on('error', error => {
-        logger.error('Error during request: ', error)
-        reject(error)
-      })
+		req.on("error", (error) => {
+			logger.error("Error during request: ", error);
+			reject(error);
+		});
 
-      req.write(payload)
+		req.write(payload);
 
-      req.end()
-  })
+		req.end();
+	});
 }

--- a/src/server/app.js
+++ b/src/server/app.js
@@ -1,45 +1,38 @@
 const createHookReceiver = require("npm-hook-receiver");
-const logger = require('../config').logger
-
-
+const logger = require("../config").logger;
 
 module.exports = ({ producer, config }) => {
-  const server = createHookReceiver({
-    secret: config.secret,
-    mount: config.mount,
-  });
-  logger.info(`Server secret: ${config.secret}`)
+	const server = createHookReceiver({
+		secret: config.secret,
+		mount: config.mount,
+	});
+	logger.info(`Server secret: ${config.secret}`);
 
-  server.on(
-    "package:publish",
-    async (package) => {
-      logger.info(`Received webhook event: ${JSON.stringify(package)}`);
+	server.on("package:publish", async (package) => {
+		logger.info(`Received webhook event: ${JSON.stringify(package)}`);
 
-      if(!package.topic) throw 'Package missing topic'
+		if (!package.topic) throw "Package missing topic";
 
-      try {
-        await producer.send({
-          topic: package.topic,
-          messages: [ get_data(package) ],
-        });
-      } catch (error) {
-        logger.error(`Failed to publish webhook message`, error);
-      }
-    }
-  );
-  server.on(
-    'hook:error',
-    (message) => {
-      logger.error('Hook receive Error: ', message)
-    }
-  )
-  
-  return server;
+		try {
+			await producer.send({
+				topic: package.topic,
+				messages: [get_data(package)],
+			});
+		} catch (error) {
+			logger.error(`Failed to publish webhook message`, error);
+		}
+	});
+	server.on("hook:error", (message) => {
+		logger.error("Hook receive Error: ", message);
+	});
+
+	return server;
 };
 
-function get_data(package){
-  return JSON.stringify({
-    'timestamp' : package.timestamp,
-    'data' : package.data,
-  })
+function get_data(package) {
+	return {
+		timestamp: package.timestamp,
+		value: `${package.data}`,
+		partition: package.partition,
+	};
 }


### PR DESCRIPTION
- fix data format when sending from webhook to kafka
- now producer has its name (name set via environment in docker-compose)
- random interval to send in each producer (e.x. in file: send accumulated +1 number w/ random interval [2000, 5000] milis), this range should become smaller when brokers run multithreading?
- created dockerfile for each producer
- add 2 example producers in docker-compose, their names: Ho Chi Minh and Vung Tau
- why am I could just publish via partition = 0, someone helps me
- no consumer has been added yet